### PR TITLE
Fix Running Error

### DIFF
--- a/script/napcat
+++ b/script/napcat
@@ -231,12 +231,12 @@ startdown() {
 
 update() {
     stop
-    sudo bash <(curl -sSL https://nclatest.znin.net/NapNeko/NapCat-Installer/main/script/install.sh) --docker n
+    sudo bash < <(curl -sSL https://nclatest.znin.net/NapNeko/NapCat-Installer/main/script/install.sh) --docker n
 }
 
 rebuild() {
     stop
-    sudo bash <(curl -sSL https://nclatest.znin.net/NapNeko/NapCat-Installer/main/script/install.sh) --docker n --force
+    sudo bash < <(curl -sSL https://nclatest.znin.net/NapNeko/NapCat-Installer/main/script/install.sh) --docker n --force
 }
 
 remove() {


### PR DESCRIPTION
Fix "bash: /dev/fd/63: No such file or directory" error that may occur when running update and rebuild.